### PR TITLE
Fix bastion floating ip setting

### DIFF
--- a/bastion_lb_web_TLS-Terminated.yml
+++ b/bastion_lb_web_TLS-Terminated.yml
@@ -101,7 +101,6 @@
           - ssh
           - internal
         network: "{{ network_name }}"
-        auto_ip: yes
         floating_ip_pools: "{{ router_attached_network }}"
         userdata: "{{ server_userdata | default(omit) }}"
         meta: "{{ server_meta | default(omit) }}"


### PR DESCRIPTION
auto_ipとfloating_ip_poolsはどちらかしか指定できないため修正